### PR TITLE
Add weight to geolocalisation points

### DIFF
--- a/src/VueGoogleHeatmap.vue
+++ b/src/VueGoogleHeatmap.vue
@@ -55,7 +55,9 @@ export default {
     },
     heatmapPoints() {
       return this.points.map(
-        point => new google.maps.LatLng(point.lat, point.lng)
+        (point) => {
+        return { location: new google.maps.LatLng(point.lat, point.lng), weight: point.weight }
+        }
       );
     }
   },


### PR DESCRIPTION
It would be great to be able to pass the weight of the lat/lng as shown in the Google maps documentation
https://developers.google.com/maps/documentation/javascript/heatmaplayer
